### PR TITLE
Add syntastic integration

### DIFF
--- a/syntax_checkers/jsonnet/jsonnet.vim
+++ b/syntax_checkers/jsonnet/jsonnet.vim
@@ -1,0 +1,45 @@
+" Vim syntastic plugin
+" Language: jsonnet
+" Author: Benjamin Staffin <benley@gmail.com>
+"
+" For details on how to add an external Syntastic checker:
+" https://github.com/scrooloose/syntastic/wiki/Syntax-Checker-Guide#external
+
+if exists("g:loaded_syntastic_jsonnet_jsonnet_checker")
+  finish
+endif
+let g:loaded_syntastic_jsonnet_jsonnet_checker = 1
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_jsonnet_jsonnet_IsAvailable() dict
+  return executable(self.getExec())
+endfunction
+
+function! SyntaxCheckers_jsonnet_jsonnet_GetLocList() dict
+
+  let errorformat =
+        \ 'STATIC ERROR:\ %f:%l:%c:%m,' .
+        \ 'STATIC ERROR:\ %f:%l:%c-%\d%#:%m,' .
+        \ '%ERUNTIME ERROR:\ %m,' .
+        \ '%C\ %#%f:(%\?%l:%c)%\?%.%#'
+
+  return SyntasticMake({
+        \ 'makeprg': self.makeprgBuild({}),
+        \ 'errorformat': errorformat })
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+      \ 'filetype': 'jsonnet',
+      \ 'name': 'jsonnet'})
+
+" Register for syntastic tab completion:
+if exists('g:syntastic_extra_filetypes')
+  call add(g:syntastic_extra_filetypes, 'jsonnet')
+else
+  let g:syntastic_extra_filetypes = ['jsonnet']
+endif
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
This isn't perfect - in particular, I don't know how to distinguish between errors where you want to point at the first item in the stack trace vs errors where you want to point at the *last* item in the stack trace.  Right now it works for all cases except for those where an error is raised inside of std.jsonnet, in which case the error still goes in the quickfix list, but without a useful line number.

Example that _doesn't_ work right:
```jsonnet
(function() true) == (function() false)
```

Everything else from jsonnet's test suite and other errors that I've tested does the right thing.