### PR TITLE
Fix a E121: Undefined variable:  error

### DIFF
--- a/autoload/jsonnet.vim
+++ b/autoload/jsonnet.vim
@@ -43,8 +43,10 @@ function! jsonnet#CheckBinPath(binName)
     if executable(a:binName)
         if exists('*exepath')
             let binPath = exepath(a:binName)
+	    return binPath
+        else
+	   return a:binName
         endif
-        return binPath
     else
         echo "vim-jsonnet: could not find '" . a:binName . "'."
         return ""


### PR DESCRIPTION
If the exists('*exepath') evaluates to false vim was returning this
error:
Error detected while processing function
<SNR>10_fmtAutosave..jsonnet#Format..jsonnet#CheckBinPath:
line    6:
E121: Undefined variable: binPath