### PR TITLE
Remove indentation setting that overrides jsonnet defaults

### DIFF
--- a/autoload/jsonnet.vim
+++ b/autoload/jsonnet.vim
@@ -79,8 +79,7 @@ function! jsonnet#Format()
     " Populate the final command.
     let l:command = l:binPath . " " . g:jsonnet_fmt_command
     " The inplace modification is default. Makes file management easier
-    " Indentation spacing is 4 by default
-    let l:command = l:command . ' -i -n 4 '
+    let l:command = l:command . ' -i '
     let l:command = l:command . g:jsonnet_fmt_options
 
     " Execute the compiled jsonnet fmt command and save the return value


### PR DESCRIPTION
With commit https://github.com/google/jsonnet/commit/0f1addef9137f2f27cd0d5dfdd33aaebba8efce9, the default indentation is set to 2. It would make sense that vim-jsonnet would follow these defaults.

I think it might be best to not merge this until a new version of jsonnet is released with these changes.  However, it has been sometime since a release so I think most people are compiling it from master. I will leave that decision up to you.