### PR TITLE
Tighten definition of multiline strings

### DIFF
--- a/syntax/jsonnet.vim
+++ b/syntax/jsonnet.vim
@@ -110,7 +110,7 @@ syn match Type "\$"
 
 syn region String start='L\="' skip='\\\\\|\\"' end='"'
 syn region String start='L\=\'' skip='\\\\\|\\\'' end='\''
-syn region String start='|||' end='|||'
+syn region String start='|||\s*\n\+\z(\s*\)' end='^\z1\@!\s*|||'
 
 " Highlight python style string formatting.
 syn match Special "%\%(([^)]\+)\)\=[-#0 +]*\d*\%(\.\d\+\)\=[hlL]\=[diouxXeEfFgGcrs%]" contained containedin=String


### PR DESCRIPTION
so that a `|||` in the middle of a multiline string does not end the string according to the syntax highlighter unless it actually ends it according to the language.

From the jsonnet spec:

> Text block, beginning with `|||`, followed by optional whitespace and a new-line. The next non-blank line must be prefixed with some non-zero length whitespace *W*. The block ends at the first subsequent line that does not begin with *W*, and it is an error if this line does not contain some optional whitespace followed by `|||`.

Prior to this change, the syntax highlighter looked for any sequence `|||` as the end-of-string marker. This causes problems in multiline strings that contain this sequence (this mostly comes up when providing example usage).

Example:

```
{
  help: |||
    To use this foo, you should specify a description like so:
      {
        description: |||
          Your description here.
        |||,
      }
  |||,
  ...
}
```

In this example, the line `Your description here.` would be considered outside any string, with the part before it and the part after it being considered two distinct strings.

We make the syntax highlighter use the same rules as the spec by making the start pattern match `|||` followed by any amount of whitespace, then any number of newlines (blank lines), then an amount of whitespace (*W* in the spec).

It uses the `\z( \)` construct to make this a subgroup accessible to the end pattern.

The end pattern uses lookaround to say that the start of the line must not match the *W* from the start token, while still being any amount of whitespace then `|||`.