### PR TITLE
docs: added instructions for neovim w/ no package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Plug 'google/vim-jsonnet'
 git clone https://github.com/google/vim-jsonnet ~/.vim/bundle/vim-jsonnet
 ```
 
+### Neovim with no Package Manager
+
+```sh
+mkdir ~/.local/share/nvim/site/pack/plugins/start
+cd ~/.local/share/nvim/site/pack/plugins/start
+git clone https://github.com/google/vim-jsonnet
+```
+
 ## More Info
 
 For more info on Jsonnet:


### PR DESCRIPTION
This worked for me using `NVIM v0.5.0-357-g405f49a9b` on OSX