### PR TITLE
feat: format visual selections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
 .*.swp
+doc/tags

--- a/autoload/jsonnet.vim
+++ b/autoload/jsonnet.vim
@@ -141,10 +141,10 @@ function! jsonnet#FormatVisual()
     " Get current visual selection
     let l:selection = jsonnet#GetVisualSelection()
 
-    " get the command first so we can test it
+    " Get the command first so we can test it
     let l:binName = g:jsonnet_fmt_command
 
-   " check if the user has installed command binary.
+    " Check if the user has installed command binary.
     let l:binPath = jsonnet#CheckBinPath(l:binName)
     if empty(l:binPath)
       return
@@ -159,15 +159,17 @@ function! jsonnet#FormatVisual()
     let l:out = jsonnet#System(l:command . " \"" . l:selection . "\"")
     let l:errorCode = v:shell_error
 
+    " Save register contents
     let reg = '"'
     let save_cb = &cb
     let regInfo = getreginfo(reg)
     try
-        norm! y{motion}
-        let keeper = getreg(reg)
+        " Set register to formatted output
         call setreg(reg,l:out)
+        " Paste formatted output
         silent exe 'norm! gv'.(reg == '"' ? '' : '"' . reg).'p`['
     finally
+        " Restore register contents
         let &cb = save_cb
         call setreg(reg, regInfo)
     endtry

--- a/autoload/jsonnet.vim
+++ b/autoload/jsonnet.vim
@@ -174,3 +174,17 @@ function! jsonnet#FormatVisual()
         call setreg(reg, regInfo)
     endtry
 endfunction
+
+" Evaluate jsonnet into vsplit, optionally use Tanka if available
+function! jsonnet#JsonnetEval()
+  " check if the file is a tanka file or not
+  let output = system("tk tool jpath " . shellescape(expand('%')))
+  if v:shell_error
+    let output = system("jsonnet " . shellescape(expand('%')))
+  else
+    let output = system("tk eval " . shellescape(expand('%')))
+  endif
+  vnew
+  setlocal nobuflisted buftype=nofile bufhidden=wipe noswapfile ft=jsonnet
+  put! = output
+endfunction

--- a/plugin/jsonnet.vim
+++ b/plugin/jsonnet.vim
@@ -29,3 +29,4 @@ augroup vim-jsonnet
    autocmd BufWritePre *.libsonnet call s:fmtAutosave()
 augroup END
 
+command! -range JsonnetFmtVis call jsonnet#FormatVisual()

--- a/syntax/jsonnet.vim
+++ b/syntax/jsonnet.vim
@@ -123,6 +123,8 @@ syn match Comment "#.*$"
 syn match Keyword "\<[a-zA-Z_][a-z0-9A-Z_]*\s*\(([^)]*)\)\?\s*+\?::\?:\?"
 
 syn region Object start="{" end="}" fold transparent
+syn region Object start="(" end=")" fold transparent
+syn region Object start="=" end=";" fold transparent
 
 syntax keyword Include import importstr
 syntax keyword Type function self super


### PR DESCRIPTION
I often find myself writing docs with Jsonnet examples. This allows me to quickly format snippets.

I've added the command `'<,'>JsonnetFmtVis` to `plugin/jsonnet.vim` so it also usable outside the Jsonnet augroup.