### PR TITLE
fix: maintain view/folds when formatting on save

### DIFF
--- a/autoload/jsonnet.vim
+++ b/autoload/jsonnet.vim
@@ -105,9 +105,11 @@ function! jsonnet#Format()
           call setfperm(expand('%'), l:originalFPerm)
         endif
         " the file has been changed outside of vim, enable reedit
+        mkview
         silent edit!
         let &fileformat = l:originalFileFormat
         let &syntax = &syntax
+        silent loadview
     elseif g:jsonnet_fmt_fail_silently == 0
         " FixMe: We could leverage the errors coming from the `jsonnetfmt` and
         " give immediate feedback to the user at every save time.


### PR DESCRIPTION
When calling format on save, vim was automatically closing all folds, this is quite
annoying. This is supposed to fix that, however I don't know this feature very well so
I might be using it wrong here.