### PR TITLE
refactor: Reduce complexity of jsonnet#Eval

### DIFF
--- a/autoload/jsonnet.vim
+++ b/autoload/jsonnet.vim
@@ -175,15 +175,9 @@ function! jsonnet#FormatVisual()
     endtry
 endfunction
 
-" Evaluate jsonnet into vsplit, optionally use Tanka if available
-function! jsonnet#JsonnetEval()
-  " check if the file is a tanka file or not
-  let output = system("tk tool jpath " . shellescape(expand('%')))
-  if v:shell_error
-    let output = system("jsonnet " . shellescape(expand('%')))
-  else
-    let output = system("tk eval " . shellescape(expand('%')))
-  endif
+" Evaluate jsonnet into vsplit
+function! jsonnet#Eval()
+  let output = system(g:jsonnet_command . ' ' . shellescape(expand('%')))
   vnew
   setlocal nobuflisted buftype=nofile bufhidden=wipe noswapfile ft=jsonnet
   put! = output

--- a/ftplugin/jsonnet.vim
+++ b/ftplugin/jsonnet.vim
@@ -4,6 +4,9 @@
 " -- fmt
 command! -nargs=0 JsonnetFmt call jsonnet#Format()
 
+" -- eval
+command! -nargs=0 JsonnetEval call jsonnet#Eval()
+
 setlocal commentstring=//\ %s
 
 


### PR DESCRIPTION
The complexity of dealing with an alternative eval command can be pushed up into `.vimrc`,
for example like this:

```
let output = system("tk tool jpath " . shellescape(expand('%')))
if v:shell_error
  let g:jsonnet_command='jsonnet -J vendor -J lib'
else
  let g:jsonnet_command='tk eval'
endif
```

This changes makes it easier for other jsonnet implementations to leverage the Eval
feature.

I also took the liberty to remove the redudant prefix on the function and expose it as
a command `JsonnetEval` in ftplugin.