### PR TITLE
feat(eval): add option to reuse buffer

### DIFF
--- a/autoload/jsonnet.vim
+++ b/autoload/jsonnet.vim
@@ -1,5 +1,3 @@
-
-
 " Options.
 
 if !exists("g:jsonnet_command")
@@ -43,19 +41,17 @@ endfunction
 " CheckBinPath checks whether the given binary exists or not and returns the
 " path of the binary. It returns an empty string if it doesn't exists.
 function! jsonnet#CheckBinPath(binName)
-
-    if executable(a:binName)
-        if exists('*exepath')
-            let binPath = exepath(a:binName)
-	    return binPath
-        else
-	   return a:binName
-        endif
+  if executable(a:binName)
+    if exists('*exepath')
+      let binPath = exepath(a:binName)
+      return binPath
     else
-        echo "vim-jsonnet: could not find '" . a:binName . "'."
-        return ""
+      return a:binName
     endif
-
+  else
+    echo "vim-jsonnet: could not find '" . a:binName . "'."
+    return ""
+  endif
 endfunction
 
 " Format calls `jsonnetfmt ... ` on the file and replaces the file with the
@@ -63,122 +59,122 @@ endfunction
 " jsonnetfmt command too.
 function! jsonnet#Format()
 
-    " Save cursor position and many other things.
-    let l:curw = winsaveview()
+  " Save cursor position and many other things.
+  let l:curw = winsaveview()
 
-    " Write current unsaved buffer to a temp file
-    let l:tmpname = tempname()
-    call writefile(getline(1, '$'), l:tmpname)
+  " Write current unsaved buffer to a temp file
+  let l:tmpname = tempname()
+  call writefile(getline(1, '$'), l:tmpname)
 
-    " get the command first so we can test it
-    let l:binName = g:jsonnet_fmt_command
+  " get the command first so we can test it
+  let l:binName = g:jsonnet_fmt_command
 
-   " check if the user has installed command binary.
-    let l:binPath = jsonnet#CheckBinPath(l:binName)
-    if empty(l:binPath)
-      return
+ " check if the user has installed command binary.
+  let l:binPath = jsonnet#CheckBinPath(l:binName)
+  if empty(l:binPath)
+    return
+  endif
+
+
+  " Populate the final command.
+  let l:command = l:binPath
+  " The inplace modification is default. Makes file management easier
+  let l:command = l:command . ' -i '
+  let l:command = l:command . g:jsonnet_fmt_options
+
+  " Execute the compiled jsonnetfmt command and save the return value
+  let l:out = jsonnet#System(l:command . " " . l:tmpname)
+  let l:errorCode = v:shell_error
+
+  if l:errorCode == 0
+    " The format command succeeded Move the formatted temp file over the
+    " current file and restore other settings
+
+    " stop undo recording
+    try | silent undojoin | catch | endtry
+
+    let l:originalFileFormat = &fileformat
+    if exists("*getfperm")
+      " save old file permissions
+      let l:originalFPerm = getfperm(expand('%'))
     endif
+    " Overwrite current file with the formatted temp file
+    call rename(l:tmpname, expand('%'))
 
-
-    " Populate the final command.
-    let l:command = l:binPath
-    " The inplace modification is default. Makes file management easier
-    let l:command = l:command . ' -i '
-    let l:command = l:command . g:jsonnet_fmt_options
-
-    " Execute the compiled jsonnetfmt command and save the return value
-    let l:out = jsonnet#System(l:command . " " . l:tmpname)
-    let l:errorCode = v:shell_error
-
-    if l:errorCode == 0
-        " The format command succeeded Move the formatted temp file over the
-        " current file and restore other settings
-
-        " stop undo recording
-        try | silent undojoin | catch | endtry
-
-        let l:originalFileFormat = &fileformat
-        if exists("*getfperm")
-          " save old file permissions
-          let l:originalFPerm = getfperm(expand('%'))
-        endif
-        " Overwrite current file with the formatted temp file
-        call rename(l:tmpname, expand('%'))
-
-        if exists("*setfperm") && l:originalFPerm != ''
-          call setfperm(expand('%'), l:originalFPerm)
-        endif
-        " the file has been changed outside of vim, enable reedit
-        mkview
-        silent edit!
-        let &fileformat = l:originalFileFormat
-        let &syntax = &syntax
-        silent loadview
-    elseif g:jsonnet_fmt_fail_silently == 0
-        " FixMe: We could leverage the errors coming from the `jsonnetfmt` and
-        " give immediate feedback to the user at every save time.
-        " Our inspiration, vim-go, opens a new list below the current edit
-        " window and shows the errors (the output of the fmt command).
-        " We are not sure whether this is desired in the vim-jsonnet community
-        " or not. Nevertheless, this else block is a suitable place to benefit
-        " from the `jsonnetfmt` errors.
+    if exists("*setfperm") && l:originalFPerm != ''
+      call setfperm(expand('%'), l:originalFPerm)
     endif
+    " the file has been changed outside of vim, enable reedit
+    mkview
+    silent edit!
+    let &fileformat = l:originalFileFormat
+    let &syntax = &syntax
+    silent loadview
+  elseif g:jsonnet_fmt_fail_silently == 0
+    " FixMe: We could leverage the errors coming from the `jsonnetfmt` and
+    " give immediate feedback to the user at every save time.
+    " Our inspiration, vim-go, opens a new list below the current edit
+    " window and shows the errors (the output of the fmt command).
+    " We are not sure whether this is desired in the vim-jsonnet community
+    " or not. Nevertheless, this else block is a suitable place to benefit
+    " from the `jsonnetfmt` errors.
+  endif
 
-    " Restore our cursor/windows positions.
-    call winrestview(l:curw)
+  " Restore our cursor/windows positions.
+  call winrestview(l:curw)
 endfunction
 
 function! jsonnet#GetVisualSelection()
-    " Source: https://stackoverflow.com/a/6271254
-    " Why is this not a built-in Vim script function?!
-    let [line_start, column_start] = getpos("'<")[1:2]
-    let [line_end, column_end] = getpos("'>")[1:2]
-    let lines = getline(line_start, line_end)
-    if len(lines) == 0
-        return ''
-    endif
-    let lines[-1] = lines[-1][: column_end - (&selection == 'inclusive' ? 1 : 2)]
-    let lines[0] = lines[0][column_start - 1:]
-    return join(lines, "\n")
+  " Source: https://stackoverflow.com/a/6271254
+  " Why is this not a built-in Vim script function?!
+  let [line_start, column_start] = getpos("'<")[1:2]
+  let [line_end, column_end] = getpos("'>")[1:2]
+  let lines = getline(line_start, line_end)
+  if len(lines) == 0
+    return ''
+  endif
+  let lines[-1] = lines[-1][: column_end - (&selection == 'inclusive' ? 1 : 2)]
+  let lines[0] = lines[0][column_start - 1:]
+  return join(lines, "\n")
 endfun
 
 " Format calls `jsonnetfmt ... ` on a Visual selection
 function! jsonnet#FormatVisual()
-    " Get current visual selection
-    let l:selection = jsonnet#GetVisualSelection()
+  " Get current visual selection
+  let l:selection = jsonnet#GetVisualSelection()
 
-    " Get the command first so we can test it
-    let l:binName = g:jsonnet_fmt_command
+  " Get the command first so we can test it
+  let l:binName = g:jsonnet_fmt_command
 
-    " Check if the user has installed command binary.
-    let l:binPath = jsonnet#CheckBinPath(l:binName)
-    if empty(l:binPath)
-      return
-    endif
+  " Check if the user has installed command binary.
+  let l:binPath = jsonnet#CheckBinPath(l:binName)
+  if empty(l:binPath)
+    return
+  endif
 
-    " Populate the final command.
-    let l:command = l:binPath
-    let l:command = l:command . ' -e '
-    let l:command = l:command . g:jsonnet_fmt_options
+  " Populate the final command.
+  let l:command = l:binPath
+  let l:command = l:command . ' -e '
+  let l:command = l:command . g:jsonnet_fmt_options
 
-    " Execute the compiled jsonnetfmt command and save the return value
-    let l:out = jsonnet#System(l:command . " \"" . l:selection . "\"")
-    let l:errorCode = v:shell_error
+  " Execute the compiled jsonnetfmt command and save the return value
+  let l:out = jsonnet#System(l:command . " \"" . l:selection . "\"")
+  let l:errorCode = v:shell_error
 
-    " Save register contents
-    let reg = '"'
-    let save_cb = &cb
-    let regInfo = getreginfo(reg)
-    try
-        " Set register to formatted output
-        call setreg(reg,l:out)
-        " Paste formatted output
-        silent exe 'norm! gv'.(reg == '"' ? '' : '"' . reg).'p`['
-    finally
-        " Restore register contents
-        let &cb = save_cb
-        call setreg(reg, regInfo)
-    endtry
+  " Save register contents
+  let reg = '"'
+  let save_cb = &cb
+  let regInfo = getreginfo(reg)
+  try
+    " Set register to formatted output
+    call setreg(reg,l:out)
+    " Paste formatted output
+    silent exe 'norm! gv'.(reg == '"' ? '' : '"' . reg).'p`['
+  finally
+    " Restore register contents
+    let &cb = save_cb
+    call setreg(reg, regInfo)
+  endtry
 endfunction
 
 " Evaluate jsonnet into vsplit

--- a/autoload/jsonnet.vim
+++ b/autoload/jsonnet.vim
@@ -18,6 +18,10 @@ if !exists('g:jsonnet_fmt_fail_silently')
   let g:jsonnet_fmt_fail_silently = 1
 endif
 
+if !exists('g:jsonnet_reuse_buffer')
+  let g:jsonnet_reuse_buffer = 0
+endif
+
 
 " System runs a shell command. It will reset the shell to /bin/sh for Unix-like
 " systems if it is executable.
@@ -180,7 +184,19 @@ endfunction
 " Evaluate jsonnet into vsplit
 function! jsonnet#Eval()
   let output = system(g:jsonnet_command . ' ' . shellescape(expand('%')))
-  vnew
+
+  if g:jsonnet_reuse_buffer != 0
+    let bnr = bufwinnr(g:jsonnet_command)
+    if bnr > 0
+      :exe bnr . "wincmd w"
+    else
+      " Create buffer if doesn't exist
+      silent execute 'vsplit ' . g:jsonnet_command
+    endif
+  else
+    vnew
+  endif
   setlocal nobuflisted buftype=nofile bufhidden=wipe noswapfile ft=jsonnet
-  put! = output
+  :%delete _
+  call setline(1, split(output, '\n'))
 endfunction

--- a/doc/vim-jsonnet.txt
+++ b/doc/vim-jsonnet.txt
@@ -30,12 +30,17 @@ INSTALL                                                           *jsonnet-insta
 ==============================================================================
 COMMANDS                                                         *jsonnet-commands*
 
+                                                                     *:JsonnetEval*
+:JsonnetEval
+
+Evaluate the current Jsonnet buffer with |'g:jsonnet_command'| and show the
+result in a vertical split.
+
                                                                       *:JsonnetFmt*
 :JsonnetFmt
 
-Filter the current Jsonnet buffer through `jsonnetfmt`.  It tries to
-preserve cursor position and avoids replacing the buffer with stderr
-output.
+Filter the current Jsonnet buffer through |'g:jsonnet_fmt_command'|.  It tries
+to preserve cursor position and avoids replacing the buffer with stderr output.
 
 ==============================================================================
 MAPPINGS                                                        *jsonnet-mappings*
@@ -43,11 +48,19 @@ MAPPINGS                                                        *jsonnet-mapping
 ==============================================================================
 FUNCTIONS                                                       *jsonnet-functions*
 
+                                                                 *jsonnet#Eval()*
+
+Evaluate the current Jsonnet buffer with |'g:jsonnet_command'| and show the result
+in a vertical split.
+
                                                                  *jsonnet#Format()*
 
-Filter the current Jsonnet buffer through `jsonnetfmt`.  It tries to
-preserve cursor position and avoids replacing the buffer with stderr
-output.
+Filter the current Jsonnet buffer through |'g:jsonnet_fmt_command'|.  It tries
+to preserve cursor position and avoids replacing the buffer with stderr output.
+
+                                                           *jsonnet#FormatVisual()*
+
+Filter the current visual selection through |'g:jsonnet_fmt_command'|.
 
 ==============================================================================
 SETTINGS                                                        *jsonnet-settings*
@@ -60,33 +73,39 @@ Use this option to auto |:JsonnetFmt| on save. By default it's enabled >
 <
                                                              *'g:jsonnet_command'*
 
-Use this option to define which tool is used to format. By default `jsonnet` is
-used >
+Use this option to define which tool is used to evaluate a buffer. By default
+`jsonnet` is used >
 
   let g:jsonnet_command = "jsonnet"
 <
+                                                        *'g:jsonnet_reuse_buffer'*
+
+Use this option reuse the buffer while calling |:JsonnetEval|. By default this
+is turned off. >
+
+  let g:jsonnet_reuse_buffer = 0
+<
                                                          *'g:jsonnet_fmt_command'*
 
-Use this option to define which <cmd> parameter is used with *g:jsonnet_command* tool.
-By default `fmt` is used >
+Use this option to define which fmt command is used. By default `jsonnetfmt` is
+used >
 
-  let g:jsonnet_fmt_command = "fmt"
+  let g:jsonnet_fmt_command = "jsonnetfmt"
 <
                                                          *'g:jsonnet_fmt_options'*
 
-Use this option to add additional options to the
-|'g:jsonnet_command'| + |'g:jsonnet_fmt_command'|. Default is empty. >
+Use this option to add additional options to the |'g:jsonnet_fmt_command'|.
+Default is empty. >
 
   let g:jsonnet_fmt_options = ''
 <
                                                    *'g:jsonnet_fmt_fail_silently'*
 
-Use this option to enable processing of
-|'g:jsonnet_command'| + |'g:jsonnet_fmt_command'| command if it fails. By default
-it is turned off. By default the error output from the
-|'g:jsonnet_command'| + |'g:jsonnet_fmt_command'| command is ignored.
-FixMe: The processing of the |'g:jsonnet_command'| + |'g:jsonnet_fmt_command'|
-is not implemented yet. So clearing this option would not do anything at this time. >
+Use this option to enable processing of |'g:jsonnet_fmt_command'| command if it
+fails. By default it is turned off. By default the error output from the
+|'g:jsonnet_fmt_command'| command is ignored.
+FixMe: The processing of the |'g:jsonnet_fmt_command'| is not implemented yet.
+So clearing this option would not do anything at this time. >
 
   let g:jsonnet_fmt_fail_silently = 1
 <


### PR DESCRIPTION
Sometimes I need a few tries to get my code just right, reusing the buffer then is beneficial while sometimes its nice to be able to compare  outputs. This option allows me to reuse the same buffer.

This PR also includes documentation updates, fixes #29. And applies consistent indent formatting of the autoload/jsonnet.vim.